### PR TITLE
Add Proxy Support to Telegram Notifications Plugin

### DIFF
--- a/telegram_notifications.php
+++ b/telegram_notifications.php
@@ -136,6 +136,10 @@ if (!function_exists('send_telegram_message')) {
         }
     
         $response = curl_exec($ch);
+
+        if(!$response){
+            $response = curl_error($ch);
+        }
         curl_close($ch);
 
         // Optionally, you can log the response for debugging
@@ -189,7 +193,7 @@ if (!function_exists('telegram_notifications_config')) {
                 "proxyType" => [
                     'FriendlyName' => 'Proxy Type',
                     'Type' => 'dropdown',
-                    'Options' => 'None,http,https,socks',
+                    'Options' => 'None,http,https,socks5,socks5h',
                     'Description' => 'Select the type of proxy to use, or choose "None" to disable proxy.',
                     'Default' => 'None',
                     ],

--- a/telegram_notifications.php
+++ b/telegram_notifications.php
@@ -47,7 +47,7 @@ if (!function_exists('telegram_notify')) {
             $message = build_message($type, $data);
 
             // send message
-            send_telegram_message($botToken, $chatID, $message, $message, [
+            send_telegram_message($botToken, $chatID, $message, [
                 'proxyType' => $proxyType,
                 'proxyHost' => $proxyHost,
                 'proxyPort' => $proxyPort,

--- a/telegram_notifications.php
+++ b/telegram_notifications.php
@@ -47,7 +47,7 @@ if (!function_exists('telegram_notify')) {
             $message = build_message($type, $data);
 
             // send message
-            send_telegram_message($botToken, $message, $chatID, $message, [
+            send_telegram_message($botToken, $chatID, $message, $message, [
                 'proxyType' => $proxyType,
                 'proxyHost' => $proxyHost,
                 'proxyPort' => $proxyPort,


### PR DESCRIPTION
This PR enhances the Telegram Notifications plugin by introducing proxy support for HTTP, HTTPS, and SOCKS protocols. Users can now configure proxy settings via the plugin's configuration page, including proxy type, host, port, username, and password.

Key changes include:

Proxy Configuration: Added fields in the plugin settings to accept proxy-related details.
Conditional Proxy Usage: Updated send_telegram_message to handle proxy settings dynamically, allowing users to disable proxy by selecting "None" as the proxy type.
This update maintains backward compatibility for users who do not wish to use a proxy. Please review and test with various proxy configurations to ensure functionality.